### PR TITLE
Fix default-branch CI failures

### DIFF
--- a/src/BlueScreen/ContainerBuilderDefinitionsBlueScreen.php
+++ b/src/BlueScreen/ContainerBuilderDefinitionsBlueScreen.php
@@ -19,7 +19,7 @@ class ContainerBuilderDefinitionsBlueScreen
 	}
 
 	/**
-	 * @return string[]|null
+	 * @return array{tab: string, panel: string}|null
 	 */
 	public function __invoke(?Throwable $e): ?array
 	{

--- a/src/BlueScreen/ContainerBuilderParametersBlueScreen.php
+++ b/src/BlueScreen/ContainerBuilderParametersBlueScreen.php
@@ -19,7 +19,7 @@ class ContainerBuilderParametersBlueScreen
 	}
 
 	/**
-	 * @return string[]|null
+	 * @return array{tab: string, panel: string}|null
 	 */
 	public function __invoke(?Throwable $e): ?array
 	{

--- a/tests/Cases/DI/TracyBlueScreensExtension.phpt
+++ b/tests/Cases/DI/TracyBlueScreensExtension.phpt
@@ -12,7 +12,6 @@ require_once __DIR__ . '/../../bootstrap.php';
 Toolkit::test(static function (): void {
 	$rf = new ReflectionClass(Debugger::getBlueScreen());
 	$panelsrf = $rf->getProperty('panels');
-	$panelsrf->setAccessible(true);
 
 	Assert::count(0, $panelsrf->getValue(Debugger::getBlueScreen()));
 


### PR DESCRIPTION
## Summary
- fix PHPStan callable shape inference by annotating both BlueScreen panel callbacks with `array{tab: string, panel: string}|null`
- fix PHP 8.5 test deprecation by removing deprecated `ReflectionProperty::setAccessible()` in the DI extension test
- keep behavior unchanged while restoring passing scheduled checks on the default branch