### PR TITLE
Code: revive MultiLogger extension

### DIFF
--- a/.docs/README.md
+++ b/.docs/README.md
@@ -6,7 +6,7 @@ Tuned Tracy Bars/Panels/BlueScreens for easy-developing.
 
 - [Setup](#setup)
 - [TracyBlueScreens - better BlueScreen panels](#tracybluescreen)
-- [NavigationPanel - navigate easily through all presenters](#navigationpanel)
+- [Logger - register additional Tracy loggers](#logger)
 
 ## Setup
 
@@ -25,6 +25,17 @@ extensions:
 
 ![Container Builder - parameters][container-builder-parameters]
 ![Container Builder - definitions][container-builder-definitions]
+
+## Logger
+
+`LoggerExtension` replaces Tracy logger with `MultiLogger` so you can register additional logger services.
+
+```neon
+extensions:
+	tracy.logger: Contributte\Tracy\DI\LoggerExtension
+```
+
+Extra loggers can then be wired in your app and added to the multi logger.
 
 [container-builder-parameters]: https://raw.githubusercontent.com/contributte/tracy/master/.docs/assets/container-builder-parameters.png "Container Builder - parameters"
 [container-builder-definitions]: https://raw.githubusercontent.com/contributte/tracy/master/.docs/assets/container-builder-definitions.png "Container Builder - definitions"

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
   ],
   "require": {
     "php": ">=8.2",
-    "tracy/tracy": "^2.9.0"
+    "tracy/tracy": "^2.11.2"
   },
   "require-dev": {
     "nette/di": "^3.1.2",

--- a/src/DI/LoggerExtension.php
+++ b/src/DI/LoggerExtension.php
@@ -1,0 +1,40 @@
+<?php declare(strict_types = 1);
+
+namespace Contributte\Tracy\DI;
+
+use Contributte\Tracy\Logger\MultiLogger;
+use Nette\DI\CompilerExtension;
+use Nette\DI\Definitions\ServiceDefinition;
+use Nette\PhpGenerator\ClassType;
+use Tracy\Debugger;
+
+class LoggerExtension extends CompilerExtension
+{
+
+	public function loadConfiguration(): void
+	{
+		$this->getContainerBuilder()
+			->addDefinition($this->prefix('logger'))
+			->setFactory(MultiLogger::class);
+	}
+
+	public function beforeCompile(): void
+	{
+		$builder = $this->getContainerBuilder();
+
+		$tracyLogger = $builder->getDefinition('tracy.logger');
+		assert($tracyLogger instanceof ServiceDefinition);
+		$tracyLogger->setAutowired(false);
+
+		$multiLogger = $builder->getDefinition($this->prefix('logger'));
+		assert($multiLogger instanceof ServiceDefinition);
+		$multiLogger->addSetup('addLogger', [$tracyLogger]);
+	}
+
+	public function afterCompile(ClassType $class): void
+	{
+		$class->getMethod('initialize')
+			->addBody('?::setLogger($this->getService(?));', [Debugger::class, $this->prefix('logger')]);
+	}
+
+}

--- a/src/Logger/MultiLogger.php
+++ b/src/Logger/MultiLogger.php
@@ -1,0 +1,25 @@
+<?php declare(strict_types = 1);
+
+namespace Contributte\Tracy\Logger;
+
+use Tracy\ILogger;
+
+class MultiLogger implements ILogger
+{
+
+	/** @var list<ILogger> */
+	private array $loggers = [];
+
+	public function addLogger(ILogger $logger): void
+	{
+		$this->loggers[] = $logger;
+	}
+
+	public function log(mixed $value, string $level = self::INFO): void
+	{
+		foreach ($this->loggers as $logger) {
+			$logger->log($value, $level);
+		}
+	}
+
+}

--- a/tests/Cases/DI/LoggerExtension.phpt
+++ b/tests/Cases/DI/LoggerExtension.phpt
@@ -1,0 +1,38 @@
+<?php declare(strict_types = 1);
+
+use Contributte\Tester\Toolkit;
+use Contributte\Tester\Utils\ContainerBuilder;
+use Contributte\Tracy\DI\LoggerExtension;
+use Contributte\Tracy\Logger\MultiLogger;
+use Nette\DI\Compiler;
+use Tester\Assert;
+use Tests\Fixtures\Logger\SpyLogger;
+use Tracy\Debugger;
+use Tracy\ILogger;
+
+require_once __DIR__ . '/../../bootstrap.php';
+
+Toolkit::test(static function (): void {
+	SpyLogger::$logs = [];
+
+	$container = ContainerBuilder::of()
+		->withCompiler(static function (Compiler $compiler): void {
+			$compiler->addConfig([
+				'services' => [
+					'tracy.logger' => SpyLogger::class,
+				],
+			]);
+
+			$compiler->addExtension('logger', new LoggerExtension());
+		})
+		->build();
+
+	$container->initialize();
+
+	Assert::type(MultiLogger::class, Debugger::getLogger());
+
+	Debugger::log('foo');
+	Assert::count(1, SpyLogger::$logs);
+	Assert::same('foo', SpyLogger::$logs[0]['value']);
+	Assert::same(ILogger::INFO, SpyLogger::$logs[0]['level']);
+});

--- a/tests/Cases/Logger/MultiLogger.phpt
+++ b/tests/Cases/Logger/MultiLogger.phpt
@@ -1,0 +1,27 @@
+<?php declare(strict_types = 1);
+
+use Contributte\Tester\Toolkit;
+use Contributte\Tracy\Logger\MultiLogger;
+use Tester\Assert;
+use Tests\Fixtures\Logger\MemoryLogger;
+use Tracy\ILogger;
+
+require_once __DIR__ . '/../../bootstrap.php';
+
+Toolkit::test(static function (): void {
+	$first = new MemoryLogger();
+	$second = new MemoryLogger();
+
+	$logger = new MultiLogger();
+	$logger->addLogger($first);
+	$logger->addLogger($second);
+	$logger->log('boom', ILogger::ERROR);
+
+	Assert::count(1, $first->logs);
+	Assert::same('boom', $first->logs[0]['value']);
+	Assert::same(ILogger::ERROR, $first->logs[0]['level']);
+
+	Assert::count(1, $second->logs);
+	Assert::same('boom', $second->logs[0]['value']);
+	Assert::same(ILogger::ERROR, $second->logs[0]['level']);
+});

--- a/tests/Fixtures/Logger/MemoryLogger.php
+++ b/tests/Fixtures/Logger/MemoryLogger.php
@@ -1,0 +1,21 @@
+<?php declare(strict_types = 1);
+
+namespace Tests\Fixtures\Logger;
+
+use Tracy\ILogger;
+
+class MemoryLogger implements ILogger
+{
+
+	/** @var list<array{value: mixed, level: string}> */
+	public array $logs = [];
+
+	public function log(mixed $value, string $level = self::INFO): void
+	{
+		$this->logs[] = [
+			'value' => $value,
+			'level' => $level,
+		];
+	}
+
+}

--- a/tests/Fixtures/Logger/SpyLogger.php
+++ b/tests/Fixtures/Logger/SpyLogger.php
@@ -1,0 +1,21 @@
+<?php declare(strict_types = 1);
+
+namespace Tests\Fixtures\Logger;
+
+use Tracy\ILogger;
+
+class SpyLogger implements ILogger
+{
+
+	/** @var list<array{value: mixed, level: string}> */
+	public static array $logs = [];
+
+	public function log(mixed $value, string $level = self::INFO): void
+	{
+		self::$logs[] = [
+			'value' => $value,
+			'level' => $level,
+		];
+	}
+
+}


### PR DESCRIPTION
## Summary
- revives the original MultiLogger idea from #28 in a form that works with the current codebase
- adds `LoggerExtension` that wraps `tracy.logger`, disables autowiring on the original logger, and sets `Debugger` logger to `MultiLogger`
- adds integration/unit tests for logger fan-out behavior and documents extension setup in `.docs/README.md`

## Verification
- `make qa`
- `make tests`

## Notes
- I could not push updates directly to `contributte:fx` (permission denied), so this PR supersedes #28 from my fork branch.