### PR TITLE
Docs: switch coverage badge to Codecov

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 <p align=center>
   <a href="https://github.com/contributte/tracy/actions"><img src="https://badgen.net/github/checks/contributte/tracy/master?tracy=300"></a>
-  <a href="https://coveralls.io/r/contributte/tracy"><img src="https://badgen.net/coveralls/c/github/contributte/tracy?tracy=300"></a>
+  <a href="https://codecov.io/gh/contributte/tracy"><img src="https://badgen.net/codecov/c/github/contributte/tracy?tracy=300"></a>
   <a href="https://packagist.org/packages/contributte/tracy"><img src="https://badgen.net/packagist/dm/contributte/tracy"></a>
   <a href="https://packagist.org/packages/contributte/tracy"><img src="https://badgen.net/packagist/v/contributte/tracy"></a>
 </p>


### PR DESCRIPTION
## What changed
- switched the README coverage badge link and image from Coveralls to Codecov
- verified the repo already uses the shared `nette-tester-coverage-v2` workflow and does not contain a `tests/.coveralls.yml` file

## Why
- completes the remaining Coveralls-to-Codecov cleanup for `contributte/tracy`
- keeps the repository aligned with contributte/contributte#72 and the pattern used in `contributte/vite`

Refs contributte/contributte#72