### PR TITLE
Remove phpdbg from coverage target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ tests:
 .PHONY: coverage
 coverage:
 ifdef GITHUB_ACTION
-	vendor/bin/tester -s -p phpdbg --colors 1 -C --coverage coverage.xml --coverage-src src tests/Cases
+	vendor/bin/tester -s -p php --colors 1 -C --coverage coverage.xml --coverage-src src tests/Cases
 else
-	vendor/bin/tester -s -p phpdbg --colors 1 -C --coverage coverage.html --coverage-src src tests/Cases
+	vendor/bin/tester -s -p php --colors 1 -C --coverage coverage.html --coverage-src src tests/Cases
 endif


### PR DESCRIPTION
## Summary

Replace `phpdbg` with `php` in the `coverage` Makefile target so Tracy follows the org-wide coverage runner change tracked in contributte/contributte#73.

## Motivation

`phpdbg` is being removed from coverage targets across Contributte. Using plain `php` keeps this repository aligned with the new approach and avoids relying on the PHPDBG SAPI.

## Changes

- switch the CI coverage command in `Makefile` from `-p phpdbg` to `-p php`
- switch the local HTML coverage command in `Makefile` from `-p phpdbg` to `-p php`

## Testing

- [ ] Tests pass locally
- [ ] CI passes
- [x] Manual verification (if applicable)
- attempted `make coverage`
- local verification is blocked because this environment uses `php` without Xdebug or PCOV, so Nette Tester reports that code coverage requires Xdebug, PCOV, or PHPDBG