### PR TITLE
Add sanitized stack trace output for AI agent diagnosis

### DIFF
--- a/src/BlueScreen/SanitizedTraceBlueScreen.php
+++ b/src/BlueScreen/SanitizedTraceBlueScreen.php
@@ -1,0 +1,28 @@
+<?php declare(strict_types = 1);
+
+namespace Contributte\Tracy\BlueScreen;
+
+use Contributte\Tracy\Sanitizer\SanitizedTrace;
+use Throwable;
+
+class SanitizedTraceBlueScreen
+{
+
+	/**
+	 * @return array{tab: string, panel: string}|null
+	 */
+	public function __invoke(?Throwable $e): ?array
+	{
+		if ($e === null) {
+			return null;
+		}
+
+		$markdown = SanitizedTrace::generate($e);
+
+		return [
+			'tab' => 'Sanitized Trace',
+			'panel' => '<pre>' . htmlspecialchars($markdown, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8') . '</pre>',
+		];
+	}
+
+}

--- a/src/DI/TracyBlueScreensExtension.php
+++ b/src/DI/TracyBlueScreensExtension.php
@@ -4,6 +4,7 @@ namespace Contributte\Tracy\DI;
 
 use Contributte\Tracy\BlueScreen\ContainerBuilderDefinitionsBlueScreen;
 use Contributte\Tracy\BlueScreen\ContainerBuilderParametersBlueScreen;
+use Contributte\Tracy\BlueScreen\SanitizedTraceBlueScreen;
 use Nette\DI\CompilerExtension;
 use Tracy\Debugger;
 
@@ -16,6 +17,7 @@ class TracyBlueScreensExtension extends CompilerExtension
 
 		Debugger::getBlueScreen()->addPanel(new ContainerBuilderParametersBlueScreen($builder));
 		Debugger::getBlueScreen()->addPanel(new ContainerBuilderDefinitionsBlueScreen($builder));
+		Debugger::getBlueScreen()->addPanel(new SanitizedTraceBlueScreen());
 	}
 
 }

--- a/src/Sanitizer/SanitizedDumper.php
+++ b/src/Sanitizer/SanitizedDumper.php
@@ -1,0 +1,81 @@
+<?php declare(strict_types = 1);
+
+namespace Contributte\Tracy\Sanitizer;
+
+use Closure;
+
+final class SanitizedDumper
+{
+
+	/**
+	 * Convert any PHP value to a sanitized type(size) string.
+	 */
+	public static function dump(mixed $value): string
+	{
+		if ($value === null) {
+			return 'null';
+		}
+
+		if (is_bool($value)) {
+			return 'bool(' . ($value ? 'true' : 'false') . ')';
+		}
+
+		if (is_int($value)) {
+			return 'int(' . strlen((string) $value) . ')';
+		}
+
+		if (is_float($value)) {
+			return 'float(' . strlen((string) $value) . ')';
+		}
+
+		if (is_string($value)) {
+			return 'string(' . strlen($value) . ')';
+		}
+
+		if (is_array($value)) {
+			return 'array(' . count($value) . ')';
+		}
+
+		if ($value instanceof Closure) {
+			return 'Closure';
+		}
+
+		if (is_object($value)) {
+			return 'object(' . $value::class . ')';
+		}
+
+		if (is_resource($value)) {
+			return 'resource(' . get_resource_type($value) . ')';
+		}
+
+		return 'unknown';
+	}
+
+	/**
+	 * Sanitize an array of function/method arguments to a comma-separated string.
+	 *
+	 * @param array<int, mixed> $args
+	 */
+	public static function dumpArgs(array $args): string
+	{
+		return implode(', ', array_map(self::dump(...), $args));
+	}
+
+	/**
+	 * Sanitize an associative array, preserving keys.
+	 *
+	 * @param array<string, mixed> $data
+	 * @return array<string, string>
+	 */
+	public static function dumpAssoc(array $data): array
+	{
+		$result = [];
+
+		foreach ($data as $key => $value) {
+			$result[$key] = self::dump($value);
+		}
+
+		return $result;
+	}
+
+}

--- a/src/Sanitizer/SanitizedTrace.php
+++ b/src/Sanitizer/SanitizedTrace.php
@@ -1,0 +1,152 @@
+<?php declare(strict_types = 1);
+
+namespace Contributte\Tracy\Sanitizer;
+
+use Throwable;
+
+final class SanitizedTrace
+{
+
+	/**
+	 * Generate a sanitized Markdown report from a Throwable.
+	 *
+	 * @param array{server?: array<string, mixed>, get?: array<string, mixed>, post?: array<string, mixed>} $requestContext
+	 */
+	public static function generate(Throwable $e, array $requestContext = []): string
+	{
+		$sections = [];
+		$sections[] = self::formatError($e);
+		$sections[] = self::formatTrace($e->getTrace());
+
+		$server = $requestContext['server'] ?? [];
+		$get = $requestContext['get'] ?? [];
+		$post = $requestContext['post'] ?? [];
+
+		$request = self::formatRequest($server, $get, $post);
+
+		if ($request !== '') {
+			$sections[] = $request;
+		}
+
+		return implode("\n\n", $sections) . "\n";
+	}
+
+	private static function formatError(Throwable $e): string
+	{
+		$class = $e::class;
+		$message = SanitizedDumper::dump($e->getMessage());
+		$file = ($e->getFile() !== '' ? $e->getFile() : 'unknown') . ':' . $e->getLine();
+
+		return sprintf("## Error: %s\nMessage: %s\nFile: %s", $class, $message, $file);
+	}
+
+	/**
+	 * @param array<int, array<string, mixed>> $trace
+	 */
+	private static function formatTrace(array $trace): string
+	{
+		$lines = ['## Stack Trace'];
+
+		foreach ($trace as $i => $frame) {
+			$file = isset($frame['file']) && is_string($frame['file']) ? $frame['file'] : 'unknown';
+			$line = isset($frame['line']) && is_int($frame['line']) ? $frame['line'] : 0;
+			$function = isset($frame['function']) && is_string($frame['function']) ? $frame['function'] : 'unknown';
+			/** @var array<int, mixed> $args */
+			$args = isset($frame['args']) && is_array($frame['args']) ? $frame['args'] : [];
+
+			$call = '';
+
+			if (isset($frame['class'], $frame['type']) && is_string($frame['class']) && is_string($frame['type'])) {
+				$call = $frame['class'] . $frame['type'];
+			}
+
+			$call .= $function . '(' . SanitizedDumper::dumpArgs($args) . ')';
+
+			$lines[] = '#' . $i . ' ' . $file . ':' . $line;
+			$lines[] = '   ' . $call;
+		}
+
+		return implode("\n", $lines);
+	}
+
+	/**
+	 * @param array<string, mixed> $server
+	 * @param array<string, mixed> $get
+	 * @param array<string, mixed> $post
+	 */
+	private static function formatRequest(array $server, array $get, array $post): string
+	{
+		$hasUrl = isset($server['REQUEST_URI']) || isset($server['REQUEST_METHOD']);
+
+		if (!$hasUrl && $get === [] && $post === []) {
+			return '';
+		}
+
+		$lines = ['## Request Context'];
+
+		if (isset($server['REQUEST_URI'])) {
+			$lines[] = 'URL: ' . SanitizedDumper::dump($server['REQUEST_URI']);
+		}
+
+		if (isset($server['REQUEST_METHOD'])) {
+			$lines[] = 'Method: ' . SanitizedDumper::dump($server['REQUEST_METHOD']);
+		}
+
+		// Headers from HTTP_* server variables
+		$headers = self::extractHeaders($server);
+
+		if ($headers !== []) {
+			$lines[] = 'Headers:';
+
+			foreach ($headers as $name => $value) {
+				$lines[] = '  ' . $name . ': ' . SanitizedDumper::dump($value);
+			}
+		}
+
+		if ($get !== []) {
+			$lines[] = 'GET:';
+
+			foreach (SanitizedDumper::dumpAssoc($get) as $key => $value) {
+				$lines[] = '  ' . $key . ': ' . $value;
+			}
+		}
+
+		if ($post !== []) {
+			$lines[] = 'POST:';
+
+			foreach (SanitizedDumper::dumpAssoc($post) as $key => $value) {
+				$lines[] = '  ' . $key . ': ' . $value;
+			}
+		}
+
+		return implode("\n", $lines);
+	}
+
+	/**
+	 * Extract HTTP headers from $_SERVER array.
+	 *
+	 * @param array<string, mixed> $server
+	 * @return array<string, mixed>
+	 */
+	private static function extractHeaders(array $server): array
+	{
+		$headers = [];
+
+		foreach ($server as $key => $value) {
+			if (!str_starts_with($key, 'HTTP_')) {
+				continue;
+			}
+
+			$name = str_replace('_', '-', substr($key, 5));
+			$name = ucwords(strtolower($name), '-');
+			$headers[$name] = $value;
+		}
+
+		if (isset($server['CONTENT_TYPE'])) {
+			$headers['Content-Type'] = $server['CONTENT_TYPE'];
+		}
+
+		return $headers;
+	}
+
+}

--- a/tests/Cases/DI/TracyBlueScreensExtension.phpt
+++ b/tests/Cases/DI/TracyBlueScreensExtension.phpt
@@ -21,5 +21,5 @@ Toolkit::test(static function (): void {
 		})
 		->build();
 
-	Assert::count(2, $panelsrf->getValue(Debugger::getBlueScreen()));
+	Assert::count(3, $panelsrf->getValue(Debugger::getBlueScreen()));
 });

--- a/tests/Cases/Sanitizer/SanitizedDumper.phpt
+++ b/tests/Cases/Sanitizer/SanitizedDumper.phpt
@@ -1,0 +1,76 @@
+<?php declare(strict_types = 1);
+
+use Contributte\Tester\Toolkit;
+use Contributte\Tracy\Sanitizer\SanitizedDumper;
+use Tester\Assert;
+
+require_once __DIR__ . '/../../bootstrap.php';
+
+// String values
+Toolkit::test(static function (): void {
+	Assert::same('string(5)', SanitizedDumper::dump('hello'));
+	Assert::same('string(0)', SanitizedDumper::dump(''));
+	Assert::same('string(11)', SanitizedDumper::dump('hello world'));
+});
+
+// Integer values
+Toolkit::test(static function (): void {
+	Assert::same('int(1)', SanitizedDumper::dump(7));
+	Assert::same('int(2)', SanitizedDumper::dump(42));
+	Assert::same('int(5)', SanitizedDumper::dump(12345));
+	Assert::same('int(2)', SanitizedDumper::dump(-5));
+	Assert::same('int(1)', SanitizedDumper::dump(0));
+});
+
+// Float values
+Toolkit::test(static function (): void {
+	Assert::same('float(4)', SanitizedDumper::dump(3.14));
+	Assert::same('float(3)', SanitizedDumper::dump(0.5));
+});
+
+// Null
+Toolkit::test(static function (): void {
+	Assert::same('null', SanitizedDumper::dump(null));
+});
+
+// Boolean values
+Toolkit::test(static function (): void {
+	Assert::same('bool(true)', SanitizedDumper::dump(true));
+	Assert::same('bool(false)', SanitizedDumper::dump(false));
+});
+
+// Array values
+Toolkit::test(static function (): void {
+	Assert::same('array(3)', SanitizedDumper::dump([1, 2, 3]));
+	Assert::same('array(0)', SanitizedDumper::dump([]));
+	Assert::same('array(2)', SanitizedDumper::dump(['nested' => [1, 2], 'key' => 'value']));
+});
+
+// Object values
+Toolkit::test(static function (): void {
+	Assert::same('object(stdClass)', SanitizedDumper::dump(new stdClass()));
+});
+
+// Closure
+Toolkit::test(static function (): void {
+	Assert::same('Closure', SanitizedDumper::dump(static function (): void {
+	}));
+	Assert::same('Closure', SanitizedDumper::dump(static fn () => 1));
+});
+
+// dumpArgs
+Toolkit::test(static function (): void {
+	Assert::same('int(1), string(5)', SanitizedDumper::dumpArgs([7, 'hello']));
+	Assert::same('', SanitizedDumper::dumpArgs([]));
+	Assert::same('null, bool(true), array(2)', SanitizedDumper::dumpArgs([null, true, [1, 2]]));
+});
+
+// dumpAssoc
+Toolkit::test(static function (): void {
+	Assert::same(['key' => 'string(3)'], SanitizedDumper::dumpAssoc(['key' => 'abc']));
+	Assert::same([], SanitizedDumper::dumpAssoc([]));
+	Assert::same(
+		['name' => 'string(4)', 'age' => 'int(2)'],
+		SanitizedDumper::dumpAssoc(['name' => 'John', 'age' => 30]),
+	);
+});

--- a/tests/Cases/Sanitizer/SanitizedTrace.phpt
+++ b/tests/Cases/Sanitizer/SanitizedTrace.phpt
@@ -1,0 +1,95 @@
+<?php declare(strict_types = 1);
+
+use Contributte\Tester\Toolkit;
+use Contributte\Tracy\Sanitizer\SanitizedTrace;
+use Tester\Assert;
+
+require_once __DIR__ . '/../../bootstrap.php';
+
+// Basic error output
+Toolkit::test(static function (): void {
+	$e = new RuntimeException('Something went wrong');
+	$output = SanitizedTrace::generate($e, [
+		'server' => [],
+		'get' => [],
+		'post' => [],
+	]);
+
+	Assert::contains('## Error: RuntimeException', $output);
+	Assert::contains('Message: string(20)', $output);
+	Assert::contains('## Stack Trace', $output);
+	// Real message must not appear
+	Assert::false(str_contains($output, 'Something went wrong'));
+});
+
+// Request context with HTTP data
+Toolkit::test(static function (): void {
+	$e = new RuntimeException('Test error');
+	$output = SanitizedTrace::generate($e, [
+		'server' => [
+			'REQUEST_URI' => '/api/orders/123',
+			'REQUEST_METHOD' => 'POST',
+			'HTTP_AUTHORIZATION' => 'Bearer secret-token-abc123',
+			'HTTP_CONTENT_TYPE' => 'application/json',
+			'CONTENT_TYPE' => 'application/json',
+		],
+		'get' => [
+			'page' => '1',
+		],
+		'post' => [
+			'order_id' => 42,
+			'payload' => ['item1', 'item2', 'item3'],
+		],
+	]);
+
+	// Section headers present
+	Assert::contains('## Request Context', $output);
+	Assert::contains('URL: string(15)', $output);
+	Assert::contains('Method: string(4)', $output);
+
+	// Headers - keys preserved, values sanitized
+	Assert::contains('Authorization: string(26)', $output);
+	Assert::contains('Content-Type: string(16)', $output);
+
+	// GET params - keys preserved
+	Assert::contains('GET:', $output);
+	Assert::contains('  page: string(1)', $output);
+
+	// POST params - keys preserved
+	Assert::contains('POST:', $output);
+	Assert::contains('  order_id: int(2)', $output);
+	Assert::contains('  payload: array(3)', $output);
+
+	// Real values must not appear
+	Assert::false(str_contains($output, '/api/orders/123'));
+	Assert::false(str_contains($output, 'secret-token-abc123'));
+	Assert::false(str_contains($output, 'Bearer'));
+	Assert::false(str_contains($output, 'application/json'));
+	Assert::false(str_contains($output, 'item1'));
+});
+
+// No request context in CLI mode
+Toolkit::test(static function (): void {
+	$e = new RuntimeException('CLI error');
+	$output = SanitizedTrace::generate($e, [
+		'server' => ['PHP_SELF' => 'test.php'],
+		'get' => [],
+		'post' => [],
+	]);
+
+	Assert::false(str_contains($output, '## Request Context'));
+});
+
+// Nested exception values are not leaked
+Toolkit::test(static function (): void {
+	$e = new InvalidArgumentException('User email: john@example.com is invalid');
+	$output = SanitizedTrace::generate($e, [
+		'server' => [],
+		'get' => [],
+		'post' => [],
+	]);
+
+	Assert::false(str_contains($output, 'john@example.com'));
+	Assert::false(str_contains($output, 'User email'));
+	Assert::contains('Message: string(39)', $output);
+});


### PR DESCRIPTION
## Summary

- Adds `SanitizedDumper` class that converts any PHP value to a type+size descriptor (e.g. `string(40)`, `int(2)`, `array(5)`, `object(Foo)`, `Closure`, `null`) — no real values are ever exposed
- Adds `SanitizedTrace` class that generates structured Markdown from a `Throwable`, including error info, stack trace with sanitized arguments, and request context (keys preserved, values replaced with type descriptors)
- Adds `SanitizedTraceBlueScreen` panel registered automatically via the DI extension, making the sanitized output available on every Tracy error page

This enables platform operators to safely pass error context to an AI agent for diagnosis without leaking sensitive customer or business data.

### Example output

```markdown
## Error: RuntimeException
Message: string(62)
File: src/Order/OrderService.php:84

## Stack Trace
#0 src/Order/OrderService.php:84
   OrderService::processPayment(int(1), string(36), array(3))
#1 src/Controller/OrderController.php:210
   OrderController::checkout(object(Request))

## Request Context
URL: string(58)
Method: string(4)
Headers:
  Content-Type: string(16)
  Authorization: string(71)
POST:
  order_id: int(1)
  payload: array(4)
```

## Test plan

- [x] `SanitizedDumper` unit tests cover all PHP types: string, int, float, bool, null, array, object, Closure, plus edge cases (empty string, negative int, nested arrays)
- [x] `SanitizedTrace` integration tests verify correct Markdown structure, request context formatting, CLI mode (no request section), and that no real values leak into output
- [x] DI extension test updated to verify 3 panels registered
- [x] PHPStan level 9 passes with no errors
- [x] Code style (phpcs) passes with no errors
- [x] All 5 test suites pass

https://claude.ai/code/session_01ErKHmRecd68B7zbeaEUqxv

---
_Generated by [Claude Code](https://claude.ai/code/session_01ErKHmRecd68B7zbeaEUqxv)_